### PR TITLE
Fix overflow style cleanup

### DIFF
--- a/src/app/core/components/error-handler/services/error-handler.service.ts
+++ b/src/app/core/components/error-handler/services/error-handler.service.ts
@@ -66,7 +66,7 @@ export class ErrorHandlerService extends BaseComponent{
    */
   public destroyErrorHandlerComponent(): void {
     if (!ErrorHandlerService.errorHandlerComponentRef) return;
-    this.renderer.removeStyle(this.document?.body, 'overflow');
+    this.renderer.removeStyle(this.document?.body, 'overflow-y');
     ErrorHandlerService.errorHandlerComponentRef.destroy();
     this.applicationRef.detachView(
       ErrorHandlerService.errorHandlerComponentRef.hostView


### PR DESCRIPTION
## Summary
- prevent body scroll locking by removing `overflow-y` style on error handler destroy

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684202a7f044833391dfb8ad22371d43