### PR TITLE
Fix language comment

### DIFF
--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -21,7 +21,7 @@ export class HeaderComponent {
   ) {}
 
   /**
-   * recupera o valor da pesquisa
+   * altera o idioma da aplicação
    */
   public setLanguage(language: string) {
     this.storageService.getLanguage


### PR DESCRIPTION
## Summary
- clarify the `setLanguage` comment in header component

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420442910c833389d9cdc804b01d42