### PR TITLE
Fix InfoCarousel interface name

### DIFF
--- a/src/app/feature/components/movie-collection/movie-collection.component.ts
+++ b/src/app/feature/components/movie-collection/movie-collection.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { StorageService } from '../../services/storage/storage.service';
-import { InfoCaroucel } from 'src/app/interfaces/info-carousel.interface';
+import { InfoCarousel } from 'src/app/interfaces/info-carousel.interface';
 import { TmbdService } from '../../services/tmdb/tmdb.service';
 import { Observable, forkJoin, take } from 'rxjs';
 import { GENRES } from 'src/app/shared/consts/genres.const';
@@ -14,13 +14,13 @@ import { FormControl } from '@angular/forms';
   styleUrls: ['./movie-collection.component.scss'],
 })
 export class MovieCollectionComponent implements OnInit {
-  public allCollection: Array<InfoCaroucel> = [];
+  public allCollection: Array<InfoCarousel> = [];
   public title: string;
   public genrers = new FormControl(['']);
   public genrerList: Array<string> = [];
   public isLoaded = false;
   private isMovie: boolean;
-  private collectionOrigin: Array<InfoCaroucel> = [];
+  private collectionOrigin: Array<InfoCarousel> = [];
 
   constructor(
     private readonly storageService: StorageService,

--- a/src/app/feature/components/popular-movies/home.component.ts
+++ b/src/app/feature/components/popular-movies/home.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { TmbdService } from '../../services/tmdb/tmdb.service';
 import { AllMovies } from 'src/app/interfaces/all-movies.interface';
 import { endpoint } from 'src/app/core/settings/url';
-import { InfoCaroucel } from 'src/app/interfaces/info-carousel.interface';
+import { InfoCarousel } from 'src/app/interfaces/info-carousel.interface';
 import { StorageService } from '../../services/storage/storage.service';
 import { BaseComponent } from 'src/app/core/components/base/base.component';
 import {
@@ -27,7 +27,7 @@ import {
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent extends BaseComponent implements OnInit {
-  public allPopular: Array<InfoCaroucel> = [];
+  public allPopular: Array<InfoCarousel> = [];
   public subscriptionLanguage!: Subscription;
   public spotlighInfos!: SpotlighInfos;
 

--- a/src/app/interfaces/info-carousel.interface.ts
+++ b/src/app/interfaces/info-carousel.interface.ts
@@ -1,6 +1,6 @@
 import { Result } from "./all-movies.interface";
 
-export interface InfoCaroucel {
+export interface InfoCarousel {
     title: string;
     results: Array<Result>
 }

--- a/src/app/shared/carousel/carousel.component.ts
+++ b/src/app/shared/carousel/carousel.component.ts
@@ -10,7 +10,7 @@ import { takeUntil } from 'rxjs';
 import { BaseComponent } from 'src/app/core/components/base/base.component';
 import { ActiveRoutes } from 'src/app/enums/routes.enum';
 import { StorageService } from 'src/app/feature/services/storage/storage.service';
-import { InfoCaroucel } from 'src/app/interfaces/info-carousel.interface';
+import { InfoCarousel } from 'src/app/interfaces/info-carousel.interface';
 
 @Component({
   selector: 'app-carousel',
@@ -19,7 +19,7 @@ import { InfoCaroucel } from 'src/app/interfaces/info-carousel.interface';
 })
 export class CarouselComponent extends BaseComponent implements AfterViewInit {
   @ViewChild(Carousel) public dragCarousel!: Carousel;
-  @Input({required: true}) public infosCarousel!: InfoCaroucel;
+  @Input({required: true}) public infosCarousel!: InfoCarousel;
   public customOptions: OwlOptions = {
     loop: true,
     autoHeight: true,


### PR DESCRIPTION
## Summary
- rename `InfoCaroucel` interface to `InfoCarousel`
- update all references across the app

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420440d57c83338092fd29e5cac427