### PR TITLE
Fix error handler style removal

### DIFF
--- a/src/app/core/components/error-handler/services/error-handler.service.spec.ts
+++ b/src/app/core/components/error-handler/services/error-handler.service.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { ApplicationRef, EnvironmentInjector, RendererFactory2 } from '@angular/core';
+import * as ngCore from '@angular/core';
+import { ErrorHandlerService } from './error-handler.service';
+import { LoaderService } from '../../loader/services/loader.service';
+
+class AppRefStub {
+  attachView() {}
+  detachView() {}
+}
+
+class Renderer2Stub {
+  setStyle(el: any, style: string, value: any) {
+    el.style[style] = value;
+  }
+  removeStyle(el: any, style: string) {
+    el.style[style] = '';
+  }
+  appendChild(parent: any, child: any) {
+    parent.appendChild(child);
+  }
+}
+
+class RendererFactory2Stub {
+  createRenderer() {
+    return new Renderer2Stub();
+  }
+}
+
+class EnvironmentInjectorStub {}
+class LoaderServiceStub {}
+
+describe('ErrorHandlerService', () => {
+  let service: ErrorHandlerService;
+  let documentRef: Document;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ErrorHandlerService,
+        { provide: ApplicationRef, useClass: AppRefStub },
+        { provide: RendererFactory2, useClass: RendererFactory2Stub },
+        { provide: EnvironmentInjector, useClass: EnvironmentInjectorStub },
+        { provide: LoaderService, useClass: LoaderServiceStub },
+      ],
+    });
+    service = TestBed.inject(ErrorHandlerService);
+    documentRef = TestBed.inject(DOCUMENT);
+    (service as any).observerLoading = { unsubscribe: () => {} };
+  });
+
+  it('should remove overflow-y style when destroyed', () => {
+    const componentRefStub = {
+      location: { nativeElement: documentRef.createElement('div') },
+      hostView: {},
+      destroy: () => {},
+    } as any;
+    spyOn(ngCore, 'createComponent').and.returnValue(componentRefStub);
+
+    service.createErrorHandler();
+    expect((documentRef.body as HTMLElement).style.overflowY).toBe('hidden');
+
+    service.destroyErrorHandlerComponent();
+    expect((documentRef.body as HTMLElement).style.overflowY).toBe('');
+  });
+});

--- a/src/app/core/components/error-handler/services/error-handler.service.ts
+++ b/src/app/core/components/error-handler/services/error-handler.service.ts
@@ -66,7 +66,7 @@ export class ErrorHandlerService extends BaseComponent{
    */
   public destroyErrorHandlerComponent(): void {
     if (!ErrorHandlerService.errorHandlerComponentRef) return;
-    this.renderer.removeStyle(this.document?.body, 'overflow');
+    this.renderer.removeStyle(this.document?.body, 'overflow-y');
     ErrorHandlerService.errorHandlerComponentRef.destroy();
     this.applicationRef.detachView(
       ErrorHandlerService.errorHandlerComponentRef.hostView


### PR DESCRIPTION
## Summary
- fix style cleanup for the error handler
- add a unit test that verifies style removal

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68420441d32c8333ba44a3a0b8723669