### PR TITLE
Fix spotlight height

### DIFF
--- a/src/app/shared/movie-spotlight/movie-spotlight.component.scss
+++ b/src/app/shared/movie-spotlight/movie-spotlight.component.scss
@@ -1,5 +1,5 @@
 .popular-movie {
-    height: 800px;
+    height: 80vh;
     width: 100%;
     background-repeat: no-repeat;
     background-size: cover;
@@ -23,8 +23,8 @@
 .popular-movie-internal {
 height: 100%;
 background-size: 100%;
-height: 80%;
-width: 80%;
+  height: 80vh;
+  width: 80vw;
 background-repeat: no-repeat;
 background-position: center;
 }


### PR DESCRIPTION
## Summary
- use viewport units for movie spotlight dimensions

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9459f0883339bece456d6162ae4