### PR TITLE
Add skeleton placeholders to movie cards

### DIFF
--- a/src/app/feature/components/movie-collection/movie-collection.component.html
+++ b/src/app/feature/components/movie-collection/movie-collection.component.html
@@ -1,4 +1,4 @@
-<section *ngIf="isLoaded">
+<section>
   <form>
     <h2 class="pt-4 ps-4">Seleção de {{title}}</h2>
     <mat-form-field>
@@ -14,7 +14,17 @@
       </mat-select>
     </mat-form-field>
   </form>
-  <ng-container *ngFor="let collection of allCollection">
-    <app-carousel  [infosCarousel]="collection"></app-carousel>
+  <ng-container *ngIf="isLoaded; else skeletonCarousel">
+    <ng-container *ngFor="let collection of allCollection">
+      <app-carousel [infosCarousel]="collection"></app-carousel>
+    </ng-container>
   </ng-container>
-  </section>
+  <ng-template #skeletonCarousel>
+    <div class="card-group">
+      <div class="skeleton-card" *ngFor="let _ of skeletons">
+        <div class="skeleton-image"></div>
+        <div class="skeleton-text"></div>
+      </div>
+    </div>
+  </ng-template>
+</section>

--- a/src/app/feature/components/movie-collection/movie-collection.component.scss
+++ b/src/app/feature/components/movie-collection/movie-collection.component.scss
@@ -5,3 +5,7 @@ section {
       width: 500px;
     }
 }
+
+.card-group {
+    display: flex;
+}

--- a/src/app/feature/components/movie-collection/movie-collection.component.ts
+++ b/src/app/feature/components/movie-collection/movie-collection.component.ts
@@ -19,6 +19,7 @@ export class MovieCollectionComponent implements OnInit {
   public genrers = new FormControl(['']);
   public genrerList: Array<string> = [];
   public isLoaded = false;
+  public skeletons = Array.from({ length: 5 });
   private isMovie: boolean;
   private collectionOrigin: Array<InfoCarousel> = [];
 

--- a/src/app/feature/components/popular-movies/home.component.html
+++ b/src/app/feature/components/popular-movies/home.component.html
@@ -1,4 +1,14 @@
-<section *ngIf="spotlighInfos">
-  <app-movie-spotlight [spotlighInfos]="spotlighInfos"></app-movie-spotlight>
-  <app-carousel *ngFor="let collection of allPopular" [infosCarousel]="collection"></app-carousel>
+<section>
+  <ng-container *ngIf="spotlighInfos; else skeletonHome">
+    <app-movie-spotlight [spotlighInfos]="spotlighInfos"></app-movie-spotlight>
+    <app-carousel *ngFor="let collection of allPopular" [infosCarousel]="collection"></app-carousel>
+  </ng-container>
+  <ng-template #skeletonHome>
+    <div class="card-group">
+      <div class="skeleton-card" *ngFor="let _ of skeletons">
+        <div class="skeleton-image"></div>
+        <div class="skeleton-text"></div>
+      </div>
+    </div>
+  </ng-template>
 </section>

--- a/src/app/feature/components/popular-movies/home.component.scss
+++ b/src/app/feature/components/popular-movies/home.component.scss
@@ -1,3 +1,7 @@
 section {
     background-color: rgb(59, 59, 59);
 }
+
+.card-group {
+    display: flex;
+}

--- a/src/app/feature/components/popular-movies/home.component.ts
+++ b/src/app/feature/components/popular-movies/home.component.ts
@@ -30,6 +30,7 @@ export class HomeComponent extends BaseComponent implements OnInit {
   public allPopular: Array<InfoCarousel> = [];
   public subscriptionLanguage!: Subscription;
   public spotlighInfos!: SpotlighInfos;
+  public skeletons = Array.from({ length: 5 });
 
   /**
    *

--- a/src/app/feature/components/search-result/search-result.component.html
+++ b/src/app/feature/components/search-result/search-result.component.html
@@ -1,18 +1,26 @@
-<section *ngIf="results.results">
+<section>
   <div class="container">
     <h2 class="pt-4 ps-4">Resultado da pesquisa:</h2>
     <div class="card-group">
-      <h3 *ngIf="!results.results.length">Nenhum resultado encontrado</h3>
-      <div *ngFor="let result of results.results" class="selected-card" (click)="selectMovie(result.id)">
-        <img [src]="result.backdrop_path ? 'https://image.tmdb.org/t/p/w500/' + result.backdrop_path : './../../../assets/img/not-image.png'" />
-        <div>{{result.title}}</div>
-      </div>
+      <ng-container *ngIf="results.results; else skeleton">
+        <h3 *ngIf="!results.results.length">Nenhum resultado encontrado</h3>
+        <div *ngFor="let result of results.results" class="selected-card" (click)="selectMovie(result.id)">
+          <img [src]="result.backdrop_path ? 'https://image.tmdb.org/t/p/w500/' + result.backdrop_path : './../../../assets/img/not-image.png'" />
+          <div>{{result.title}}</div>
+        </div>
+      </ng-container>
+      <ng-template #skeleton>
+        <div class="skeleton-card" *ngFor="let _ of skeletons">
+          <div class="skeleton-image"></div>
+          <div class="skeleton-text"></div>
+        </div>
+      </ng-template>
     </div>
   </div>
-  <mat-paginator [color]="'primary'"
+  <mat-paginator *ngIf="results.results" [color]="'primary'"
        [length]="results.total_results"
               [pageSize]="results.results.length"
               (page)="handlePageEvent($event)"
               aria-label="Select page">
-</mat-paginator>
+  </mat-paginator>
 </section>

--- a/src/app/feature/components/search-result/search-result.component.ts
+++ b/src/app/feature/components/search-result/search-result.component.ts
@@ -15,6 +15,7 @@ import { ActiveRoutes } from 'src/app/enums/routes.enum';
 export class SearchResultComponent implements OnInit {
   public results: any = [];
   public theme: ThemePalette;
+  public skeletons = Array.from({ length: 8 });
 
   constructor(private readonly tmbdService: TmbdService, private readonly storageService: StorageService, private readonly router: Router) { }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,3 +9,36 @@ html, body {
     color: aliceblue;
     background-color: rgb(59, 59, 59);
 }
+
+.skeleton-card {
+  width: 200px;
+  margin: 10px;
+}
+
+.skeleton-image,
+.skeleton-text {
+  background: #e0e0e0;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+.skeleton-image {
+  height: 200px;
+  width: 100%;
+}
+
+.skeleton-text {
+  height: 20px;
+  margin-top: 5px;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- show skeleton cards while movie lists load
- apply skeleton placeholders to search results, movie collections and home page
- add global skeleton styles for card layout

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6842e96c67588333842315f16ee136e4