### PR TITLE
Melhora navegação móvel

### DIFF
--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -1,14 +1,28 @@
-<mat-toolbar color="primary">
-  <div class="col-8">
-    <button mat-button color="basic" (click)="navigate(routes.HOME)">
-      <mat-icon aria-hidden="false" aria-label="home icon" fontIcon="home"></mat-icon>
-      Home</button>
-    <button mat-button color="basic" (click)="navigate(routes.COLLECTION, typeCollection.MOVIE)">Filmes</button>
-    <button mat-button color="basic" (click)="navigate(routes.COLLECTION, typeCollection.SERIE)">Séries</button>
-    <button mat-button color="basic" (click)="navigate(routes.HOME)" [disabled]="true">Favoritos</button>
-  </div>
-  <div class="col-4">
-    <app-aside-search (valueSeachMovie)="searching($event)"></app-aside-search>
-  </div>
+<mat-drawer-container>
+  <mat-drawer #drawer mode="over" class="app-sidenav">
+    <button mat-button (click)="navigate(routes.HOME); drawer.close()">
+      <mat-icon fontIcon="home" aria-hidden="false" aria-label="home icon"></mat-icon>
+      Home
+    </button>
+    <button mat-button (click)="navigate(routes.COLLECTION, typeCollection.MOVIE); drawer.close()">Filmes</button>
+    <button mat-button (click)="navigate(routes.COLLECTION, typeCollection.SERIE); drawer.close()">Séries</button>
+    <button mat-button disabled>Favoritos</button>
+    <app-aside-search class="drawer-search" (valueSeachMovie)="searching($event)"></app-aside-search>
+  </mat-drawer>
 
-</mat-toolbar>
+  <mat-toolbar color="primary">
+    <button mat-icon-button *ngIf="isMobile" (click)="drawer.toggle()" aria-label="toggle menu">
+      <mat-icon fontIcon="menu"></mat-icon>
+    </button>
+    <div class="nav-buttons" *ngIf="!isMobile">
+      <button mat-button color="basic" (click)="navigate(routes.HOME)">
+        <mat-icon fontIcon="home" aria-hidden="false" aria-label="home icon"></mat-icon>
+        Home</button>
+      <button mat-button color="basic" (click)="navigate(routes.COLLECTION, typeCollection.MOVIE)">Filmes</button>
+      <button mat-button color="basic" (click)="navigate(routes.COLLECTION, typeCollection.SERIE)">Séries</button>
+      <button mat-button color="basic" disabled>Favoritos</button>
+    </div>
+    <span class="spacer"></span>
+    <app-aside-search *ngIf="!isMobile" (valueSeachMovie)="searching($event)"></app-aside-search>
+  </mat-toolbar>
+</mat-drawer-container>

--- a/src/app/core/components/header/header.component.scss
+++ b/src/app/core/components/header/header.component.scss
@@ -1,20 +1,15 @@
 mat-toolbar {
-    height: 80px;
+  height: 80px;
+  display: flex;
+  align-items: center;
 
-    :first-child {
-        height: 100%;
-    }
-
-    mat-drawer-container {
-        ::ng-deep {
-            mat-drawer-content {
-                overflow: hidden;
-                mat-drawer {
-                    div {
-                        overflow: hidden;
-                    }
-                }
-            }
-        }
-    }
+  .spacer {
+    flex: 1 1 auto;
+  }
 }
+
+.app-sidenav {
+  width: 250px;
+  padding: 1rem;
+}
+

--- a/src/app/core/components/header/header.component.spec.ts
+++ b/src/app/core/components/header/header.component.spec.ts
@@ -4,6 +4,7 @@ import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { HeaderComponent } from './header.component';
+import { HeaderModule } from './header.module';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -11,7 +12,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
+      imports: [HeaderModule]
     })
     .compileComponents();
   }));

--- a/src/app/core/components/header/header.component.ts
+++ b/src/app/core/components/header/header.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Output } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { StorageService } from './../../../feature/services/storage/storage.service';
 import { debounceTime, take } from 'rxjs';
 import { ActiveRoutes } from 'src/app/enums/routes.enum';
@@ -14,11 +15,17 @@ export class HeaderComponent {
   @Output() valueSeachMovie = new EventEmitter<string>();
   public routes = ActiveRoutes;
   public typeCollection = TypeCollection;
+  public isMobile = false;
 
   constructor(
     private readonly storageService: StorageService,
-    private readonly router: Router
-  ) {}
+    private readonly router: Router,
+    private readonly breakpointObserver: BreakpointObserver
+  ) {
+    this.breakpointObserver
+      .observe([Breakpoints.Handset])
+      .subscribe(result => (this.isMobile = result.matches));
+  }
 
   /**
    * altera o idioma da aplicação

--- a/src/app/core/components/header/header.module.ts
+++ b/src/app/core/components/header/header.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HeaderComponent } from './header.component';
-import {MatToolbarModule} from '@angular/material/toolbar'
-import {MatButtonModule} from '@angular/material/button';
-import {MatIconModule} from '@angular/material/icon';
-import {MatMenuModule} from '@angular/material/menu';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { LayoutModule } from '@angular/cdk/layout';
 
 import { AsideSearchModule } from 'src/app/shared/aside-search/aside-search.module';
 import { RouterModule } from '@angular/router';
@@ -17,6 +19,8 @@ import { RouterModule } from '@angular/router';
     MatIconModule,
     AsideSearchModule,
     MatMenuModule,
+    MatSidenavModule,
+    LayoutModule,
     RouterModule
   ],
   declarations: [HeaderComponent],


### PR DESCRIPTION
## Summary
- convert header toolbar to a responsive sidenav
- show search box without fixed grid columns
- load Material sidenav and layout modules

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9547b6083339a32e594b9acdadb